### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Tawsel-ltd/27dd7771-205d-4976-aab5-606e78257954/10eec291-79ae-4459-8898-2b86452c9bfe/_apis/work/boardbadge/7d55a76f-933e-486a-b4f3-e7c25d3ba22a)](https://dev.azure.com/Tawsel-ltd/27dd7771-205d-4976-aab5-606e78257954/_boards/board/t/10eec291-79ae-4459-8898-2b86452c9bfe/Microsoft.RequirementCategory)
 # tawsel
 project T
 Hello , we can do this


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Tawsel-ltd/27dd7771-205d-4976-aab5-606e78257954/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.